### PR TITLE
H3 to H2

### DIFF
--- a/classes/class-membership-chapter.php
+++ b/classes/class-membership-chapter.php
@@ -215,7 +215,7 @@ class Membership_Chapter {
 	public static function show_extra_profile_fields( $user ) {
 		$chapters = Membership_Chapter::getAllChapters();
 		?>
-		<h3><?php _e('Chapter', 'pmpro');?></h3>
+		<h2><?php _e('Chapter', 'pmpro');?></h2>
 		<?php
 			//if no chapters yet, bail
 			if(empty($chapters)) {


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.